### PR TITLE
Update Geth version to 1.4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Pedro Branco <branco@uphold.com> (@pedrobranco)
 RUN apk add --no-cache su-exec
 
 ENV GETH_DATA=/home/ethereum/.geth \
-  GETH_VERSION=1.4.5 \
-  GETH_SHASUM="a50b1facda1cb71b0bcd1658a5ce2af2e16a427d56b5057da2582c225cf5a9e2  v1.4.5.tar.gz"
+  GETH_VERSION=1.4.9 \
+  GETH_SHASUM="ff877be0c1d275f8c3a0cfd258c688b4735ea753440ad53d3cdafebb13fbf804  v1.4.9.tar.gz"
 
 RUN apk add --no-cache --virtual build-dependencies \
   gcc \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An Ethereum Go client/full-node implementation docker image.
 [![uphold/geth][docker-pulls-image]][docker-hub-url] [![uphold/geth][docker-stars-image]][docker-hub-url] [![uphold/geth][docker-size-image]][docker-hub-url] [![uphold/geth][docker-layers-image]][docker-hub-url]
 
 ## Supported tags
-- `1.4.5`, `latest` ([Dockerfile](/Dockerfile))
+- `1.4`, `1.4.9`, `latest` ([Dockerfile](/Dockerfile))
+- `1.4.5`
 
 ## What is geth?
 [Geth](https://github.com/ethereum/go-ethereum/wiki/geth) is the command line interface for running a full Ethereum node implemented in Go. It is the main deliverable of the [Frontier Release](https://github.com/ethereum/go-ethereum/wiki/Frontier).


### PR DESCRIPTION
This PR update Geth to version 1.4.9.

Todo:
- [ ] Generate tags in https://hub.docker.com/r/uphold/geth/

/cc @uphold/crypto 